### PR TITLE
explicitly sent the single channel into channels param.

### DIFF
--- a/src/Pusher.php
+++ b/src/Pusher.php
@@ -1101,11 +1101,12 @@ class Pusher implements LoggerAwareInterface, PusherInterface
         $post_params['name'] = $event;
         $post_params['data'] = $data_encoded;
         $channel_values = array_values($channels);
-        if (count($channel_values) == 1) {
-          $post_params['channel'] = $channel_values[0];
-        } else {
-          $post_params['channels'] = $channel_values;
-        }
+        // if (count($channel_values) == 1) {
+        //   $post_params['channel'] = $channel_values[0];
+        // } else {
+        //   $post_params['channels'] = $channel_values;
+        // }
+        $post_params['channels'] = $channel_values;
         if (!is_null($info)) {
           $post_params['info'] = $info;
         }


### PR DESCRIPTION
by default, when we send a single channel in Laravel 9 with Laravel-WebSockets, on the front end, it never caught. Ref. question - https://stackoverflow.com/q/74713734/7182381

## Description

Add a short description of the change. If this is related to an issue, please add a reference to the issue.

## CHANGELOG

* [CHANGED] Describe your change here. Look at CHANGELOG.md to see the format.
